### PR TITLE
Add TLS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,6 @@ deps:
 	luarocks install luasocket
 	luarocks install lua-cjson
 	luarocks install uuid
+	luarocks install luasec
 
 .PHONY: test test-deps deps

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Requirements
 * [lua-cjson](https://github.com/mpx/lua-cjson)
 * [uuid](https://github.com/Tieske/uuid)
 * [nats](https://github.com/derekcollison/nats) or [gnatsd](https://github.com/apcera/gnatsd)
+* [luasec](https://github.com/lunarmodules/luasec) if TLS support is needed
 
 This is a NATS Lua library for Lua 5.1, 5.2 and 5.3. The
 libraries are copyright by their author 2015 (see the Creators
@@ -91,6 +92,22 @@ local user, password = 'user', 'password'
 client:set_auth(user, password)
 
 -- connect to the server
+client:connect()
+```
+
+### Basic usage: TLS connection
+
+```lua
+local nats = require 'nats'
+
+local client = nats.connect({
+    host = '127.0.0.1',
+    port = 4222,
+    tls = true,
+    tls_ca_path = '/etc/ssl/certs',
+})
+
+-- connect to the server using TLS and validating the server certificate
 client:connect()
 ```
 

--- a/src/nats.lua
+++ b/src/nats.lua
@@ -339,10 +339,11 @@ end
 
 function command.connect(client)
     local config = {
-        lang     = client.lang,
-        version  = client.version,
-        verbose  = client.verbose,
-        pedantic = client.pedantic,
+        lang         = client.lang,
+        version      = client.version,
+        verbose      = client.verbose,
+        pedantic     = client.pedantic,
+        tls_required = client.parameters.tls,
     }
 
     if client.user ~= nil and client.pass ~= nil then

--- a/src/nats.lua
+++ b/src/nats.lua
@@ -232,7 +232,11 @@ client_prototype.get_server_info = function(client)
 end
 
 client_prototype.upgrade_to_tls = function(client)
-    local luasec = require('ssl')
+    local status, luasec = pcall(require, 'ssl')
+    if not status then
+        nats.error('TLS is required but the luasec library is not available')
+        return
+    end
     local params = {
         capath = client.parameters.tls_ca_path,
         cafile = client.parameters.tls_ca_file,

--- a/src/nats.lua
+++ b/src/nats.lua
@@ -38,7 +38,7 @@ local defaults = {
     tls_ca_path = nil,
     tls_ca_file = nil,
     tls_cert    = nil,
-    tls_key     = nil
+    tls_key     = nil,
 }
 
 -- ### Create a properly formatted inbox subject.

--- a/src/nats.lua
+++ b/src/nats.lua
@@ -355,8 +355,12 @@ function command.connect(client)
     local data = response.read(client)
     if data.action == 'INFO' then
         client.information = cjson.decode(data.content)
-        if client.parameters.tls and (client.information['tls_available'] or client.information['tls_required']) then
-            client:upgrade_to_tls()
+        if client.parameters.tls then
+            if (client.information['tls_available'] or client.information['tls_required']) then
+                client:upgrade_to_tls()
+            else
+                nats.error('TLS is required but not offered by the server')
+            end
         end
     end
 

--- a/src/nats.lua
+++ b/src/nats.lua
@@ -235,7 +235,6 @@ client_prototype.upgrade_to_tls = function(client)
     local status, luasec = pcall(require, 'ssl')
     if not status then
         nats.error('TLS is required but the luasec library is not available')
-        return
     end
     local params = {
         capath = client.parameters.tls_ca_path,

--- a/src/nats.lua
+++ b/src/nats.lua
@@ -293,7 +293,10 @@ local function create_connection(parameters)
     else
         if parameters.scheme then
             local scheme = parameters.scheme
-            assert(scheme == 'nats' or scheme == 'tcp', 'invalid scheme: '..scheme)
+            assert(scheme == 'nats' or scheme == 'tcp' or scheme == 'tls', 'invalid scheme: '..scheme)
+            if scheme == 'tls' then
+                parameters.tls = true
+            end
         end
         perform_connection, socket = connect_tcp, require('socket').tcp
     end


### PR DESCRIPTION
This is a copy of the pull request [1] I initially opened in the https://github.com/DawnAngel/lua-nats/ repository. It unfortunately looks like DawnAngel's repository is no longer maintained, so I'm forking it here.

Hi!

This pull request implements TLS support using the [luasec](https://github.com/lunarmodules/luasec) library, as an optional dependency.

I tested against the NATS Docker image by first generating a CA then using it to sign a certificate and a key, and starting the NATS server with:
```shell
docker run -v /path/to/server.pem:/tmp/server.cert -v /path/to/server.key:/tmp/server.key -v /path/to/ca.pem:/tmp/ca.pem -p 4223:4222 -ti nats:latest --tlscert /tmp/server.cert --tlskey /tmp/server.key --tlscacert /tmp/ca.pem
```
then connecting with:
```lua
local client = nats.connect({
    host = '127.0.0.1',
    port = 4222,
    tls = true,
    tls_ca_file = '/path/to/ca.pem',
})
```
The generation setup is basically the one used in https://github.com/PowerDNS/pdns/blob/master/regression-tests.dnsdist/Makefile, if that helps.

Please feel free to ask for any kind of changes, as the existing code is very well-structured and while I tried hard to keep it that way, I'm pretty sure it's not perfect!

It closes https://github.com/DawnAngel/lua-nats/issues/4

Best regards,

Remi Gacogne
PowerDNS.com B.V

[1]: https://github.com/DawnAngel/lua-nats/pull/7